### PR TITLE
avoid passing through hex strings when computing digests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ categories = ["cryptography"]
 [features]
 default = ["usegmp", "keygen", "proofs"]
 keygen = []
-proofs = ["ring", "data-encoding"]
+proofs = ["ring"]
 useramp = ["ramp"]
 useframp = ["framp"]
 usenum = ["num"]
@@ -40,7 +40,6 @@ framp = { version="0.3", optional=true }
 num = { version="0.1", optional=true }
 rust-gmp = { version="0.4", optional=true }
 ring = { version="0.12", optional=true }
-data-encoding = { version="2.1", optional=true }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/src/arithimpl/gmpimpl.rs
+++ b/src/arithimpl/gmpimpl.rs
@@ -5,8 +5,6 @@ extern crate gmp;
 use super::traits::*;
 use self::gmp::mpz::Mpz;
 use rand::{OsRng, Rng};
-use ring::digest::Digest;
-use data_encoding::HEXLOWER;
 
 impl Samplable for Mpz {
 
@@ -118,18 +116,6 @@ impl ConvertFrom<Mpz> for i64 {
     fn _from(x: &Mpz) -> i64 {
         let foo: Option<u64> = x.into();
         foo.unwrap() as i64
-    }
-}
-
-impl ToString for Mpz {
-    fn to_hex_str(a: &Self) -> String { a.to_str_radix(16) }
-}
-
-impl FromString<Mpz> for Mpz {
-    fn from_hex_str(a: &str) -> Mpz { Mpz::from_str_radix(a, 16).unwrap() }
-
-    fn get_from_digest(digest: Digest) -> Mpz {
-        Mpz::from_hex_str(HEXLOWER.encode(digest.as_ref()).as_str())
     }
 }
 

--- a/src/arithimpl/traits.rs
+++ b/src/arithimpl/traits.rs
@@ -1,6 +1,4 @@
-
 use std::marker::Sized;
-use ring::digest::Digest;
 
 pub trait NumberTests {
     fn is_zero(&Self) -> bool;
@@ -42,15 +40,6 @@ pub trait BitManipulation {
 
 pub trait ConvertFrom<T> {
     fn _from(&T) -> Self;
-}
-
-pub trait ToString {
-    fn to_hex_str(a: &Self) -> String;
-}
-
-pub trait FromString<I> {
-    fn from_hex_str(a: &str) -> I;
-    fn get_from_digest(digest: Digest) -> I;
 }
 
 use std::ops::{Add, Sub, Mul, Div, Rem, Shr, Neg};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@ extern crate rand;
 extern crate num_traits;
 #[cfg(feature="proofs")]
 extern crate ring;
-#[cfg(feature="proofs")]
-extern crate data_encoding;
 
 pub mod arithimpl;
 pub mod traits;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -66,12 +66,12 @@ pub trait ProveCorrectKey<EK, DK> {
 fn compute_digest<IT>(values: IT) -> BigInt
 where  IT: Iterator, IT::Item: Borrow<BigInt>
 {
-    // TODO[Morten] use https://github.com/fizyk20/rust-gmp/pull/4/files instead of convertion to hex?
     let mut digest = Context::new(&SHA256);
     for value in values {
-        digest.update(ToString::to_hex_str(value.borrow()).as_bytes());
+        let bytes: Vec<u8> = value.borrow().into();
+        digest.update(&bytes);
     }
-    BigInt::get_from_digest(digest.finish())
+    BigInt::from(digest.finish().as_ref())
 }
 
 impl ProveCorrectKey<EncryptionKey, DecryptionKey> for Paillier


### PR DESCRIPTION
FYI @gbenattar

Convert bigints directly to bytes instead of going via hex strings; should be better performance wise.