### PR TITLE
Fix crates.io shield link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Paillier
 
 [![Build Status](https://travis-ci.org/snipsco/rust-paillier.svg)](https://travis-ci.org/snipsco/rust-paillier)
-[![Latest version](https://img.shields.io/crates/v/paillier.svg)](https://img.shields.io/crates/v/paillier.svg)
+[![Latest version](https://img.shields.io/crates/v/paillier.svg)](https://crates.io/crates/paillier)
 [![License: MIT/Apache2](https://img.shields.io/badge/license-MIT%2fApache2-blue.svg)](https://img.shields.io/badge/license-MIT%2fApache2-blue.svg)
 
 Efficient pure-Rust library for the [Paillier](https://en.wikipedia.org/wiki/Paillier_cryptosystem) partially homomorphic encryption scheme, offering encoding of both scalars and vectors (for encrypting several values together).


### PR DESCRIPTION
Current link points to https://img.shields.io/crates/v/paillier.svg (instead of https://crates.io/crates/paillier)