### PR TITLE
Alternative encryption using decryption key (and in parallel)

### DIFF
--- a/benches/encryption.rs
+++ b/benches/encryption.rs
@@ -9,12 +9,21 @@ use paillier::*;
 mod helpers;
 use helpers::*;
 
-pub fn bench_encryption<KS: KeySize>(b: &mut Bencher) {
+pub fn bench_encryption_ek<KS: KeySize>(b: &mut Bencher) {
     let ref keypair = KS::keypair();
     let ek = EncryptionKey::from(keypair);
     let m = RawPlaintext::from(10);
     b.iter(|| {
         let _ = Paillier::encrypt(&ek, &m);
+    });
+}
+
+pub fn bench_encryption_dk<KS: KeySize>(b: &mut Bencher) {
+    let ref keypair = KS::keypair();
+    let dk = DecryptionKey::from(keypair);
+    let m = RawPlaintext::from(10);
+    b.iter(|| {
+        let _ = Paillier::encrypt(&dk, &m);
     });
 }
 
@@ -69,7 +78,8 @@ pub fn bench_multiplication<KS: KeySize>(b: &mut Bencher) {
 }
 
 benchmark_group!(ks_2048,
-    self::bench_encryption<KeySize2048>,
+    self::bench_encryption_ek<KeySize2048>,
+    self::bench_encryption_dk<KeySize2048>,
     self::bench_decryption<KeySize2048>,
     self::bench_rerandomisation<KeySize2048>,
     self::bench_addition<KeySize2048>,
@@ -77,7 +87,8 @@ benchmark_group!(ks_2048,
 );
 
 benchmark_group!(ks_4096,
-    self::bench_encryption<KeySize4096>,
+    self::bench_encryption_ek<KeySize4096>,
+    self::bench_encryption_dk<KeySize4096>,
     self::bench_decryption<KeySize4096>,
     self::bench_rerandomisation<KeySize4096>,
     self::bench_addition<KeySize4096>,

--- a/src/core.rs
+++ b/src/core.rs
@@ -158,6 +158,7 @@ impl<'m, 'r> EncryptWithChosenRandomness<EncryptionKey, &'m RawPlaintext, &'r Pr
 impl<'m> Encrypt<DecryptionKey, &'m RawPlaintext, RawCiphertext> for Paillier {
     fn encrypt(dk: &DecryptionKey, m: &'m RawPlaintext) -> RawCiphertext {
         let (mp, mq) = crt_decompose(&m.0, &dk.pp, &dk.qq);
+        
         let (cp, cq) = join(
             || {
                 let rp = BigInt::sample_below(&dk.p);
@@ -174,6 +175,17 @@ impl<'m> Encrypt<DecryptionKey, &'m RawPlaintext, RawCiphertext> for Paillier {
                 cq
             }
         );
+
+        // let rp = BigInt::sample_below(&dk.p);
+        // let rnp = BigInt::modpow(&rp, &dk.n, &dk.pp);
+        // let gmp = (1 + mp * &dk.n) % &dk.pp; // TODO[Morten] maybe there's more to get here
+        // let cp = (gmp * rnp) % &dk.pp;
+        
+        // let rq = BigInt::sample_below(&dk.q);
+        // let rnq = BigInt::modpow(&rq, &dk.n, &dk.qq);
+        // let gmq = (1 + mq * &dk.n) % &dk.qq; // TODO[Morten] maybe there's more to get here
+        // let cq = (gmq * rnq) % &dk.qq;
+
         let c = crt_recombine(cp, cq, &dk.pp, &dk.qq, &dk.ppinv);
         RawCiphertext(c)
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,6 +3,8 @@
 use std::fmt;
 use std::borrow::Borrow;
 
+use rayon::join;
+
 use ::traits::*;
 use ::arithimpl::traits::*;
 use ::BigInteger as BigInt;
@@ -153,6 +155,61 @@ impl<'m, 'r> EncryptWithChosenRandomness<EncryptionKey, &'m RawPlaintext, &'r Pr
     }
 }
 
+impl<'m> Encrypt<DecryptionKey, &'m RawPlaintext, RawCiphertext> for Paillier {
+    fn encrypt(dk: &DecryptionKey, m: &'m RawPlaintext) -> RawCiphertext {
+        let (mp, mq) = crt_decompose(&m.0, &dk.pp, &dk.qq);
+        let (cp, cq) = join(
+            || {
+                let rp = BigInt::sample_below(&dk.p);
+                let rnp = BigInt::modpow(&rp, &dk.n, &dk.pp);
+                let gmp = (1 + mp * &dk.n) % &dk.pp; // TODO[Morten] maybe there's more to get here
+                let cp = (gmp * rnp) % &dk.pp;
+                cp
+            },
+            || {
+                let rq = BigInt::sample_below(&dk.q);
+                let rnq = BigInt::modpow(&rq, &dk.n, &dk.qq);
+                let gmq = (1 + mq * &dk.n) % &dk.qq; // TODO[Morten] maybe there's more to get here
+                let cq = (gmq * rnq) % &dk.qq;
+                cq
+            }
+        );
+        let c = crt_recombine(cp, cq, &dk.pp, &dk.qq, &dk.ppinv);
+        RawCiphertext(c)
+    }
+}
+
+impl<'m, 'r> EncryptWithChosenRandomness<DecryptionKey, &'m RawPlaintext, &'r Randomness, RawCiphertext> for Paillier {
+    fn encrypt_with_chosen_randomness(dk: &DecryptionKey, m: &'m RawPlaintext, r: &'r Randomness) -> RawCiphertext {
+        let (mp, mq) = crt_decompose(&m.0, &dk.pp, &dk.qq);
+        let (rp, rq) = crt_decompose(&r.0, &dk.pp, &dk.qq);
+        let (cp, cq) = join(
+            || {
+                let rnp = BigInt::modpow(&rp, &dk.n, &dk.pp);
+                let gmp = (1 + mp * &dk.n) % &dk.pp; // TODO[Morten] maybe there's more to get here
+                let cp = (gmp * rnp) % &dk.pp;
+                cp
+            },
+            || {
+                let rnq = BigInt::modpow(&rq, &dk.n, &dk.qq);
+                let gmq = (1 + mq * &dk.n) % &dk.qq; // TODO[Morten] maybe there's more to get here
+                let cq = (gmq * rnq) % &dk.qq;
+                cq
+            }
+        );
+        let c = crt_recombine(cp, cq, &dk.pp, &dk.qq, &dk.ppinv);
+        RawCiphertext(c)
+    }
+}
+
+impl<'m, 'r> EncryptWithChosenRandomness<DecryptionKey, &'m RawPlaintext, &'r PrecomputedRandomness, RawCiphertext> for Paillier {
+    fn encrypt_with_chosen_randomness(dk: &DecryptionKey, m: &'m RawPlaintext, rn: &'r PrecomputedRandomness) -> RawCiphertext {
+        let gm = (1 + &m.0 * &dk.n) % &dk.nn;
+        let c = (gm * &rn.0) % &dk.nn;
+        RawCiphertext(c)
+    }
+}
+
 // impl<PT, CT> Encrypt<EncryptionKey, PT, CT> for EncryptionKey
 // where Self: Encrypt<EncryptionKey, PT, CT>
 // {
@@ -238,12 +295,13 @@ impl<'kp> From<&'kp Keypair> for DecryptionKey {
         let (dp, dq) = crt_decompose(dn, &pminusone, &qminusone);
 
         let pinv = BigInt::modinv(&p, &q);
+        let ppinv = BigInt::modinv(&pp, &qq);
 
         let hp = h(&p, &pp, &n);
         let hq = h(&q, &qq, &n);
 
         DecryptionKey {
-            p, pp, pminusone, pinv,
+            p, pp, pminusone, pinv, ppinv,
             q, qq, qminusone,
             n, nn,
             phi,
@@ -279,11 +337,22 @@ mod tests {
     }
 
     #[test]
-    fn test_correct_encryption_decryption() {
+    fn test_correct_encryption_decryption1() {
         let (ek, dk) = test_keypair().keys();
 
         let m = RawPlaintext::from(10);
         let c = Paillier::encrypt(&ek, &m);
+
+        let recovered_m = Paillier::decrypt(&dk, &c);
+        assert_eq!(recovered_m, m);
+    }
+
+    #[test]
+    fn test_correct_encryption_decryption2() {
+        let (_, dk) = test_keypair().keys();
+
+        let m = RawPlaintext::from(10);
+        let c = Paillier::encrypt(&dk, &m);
 
         let recovered_m = Paillier::decrypt(&dk, &c);
         assert_eq!(recovered_m, m);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub struct DecryptionKey {
     dp: BigInteger,
     dq: BigInteger,
     pinv: BigInteger,
+    ppinv: BigInteger,
     hp: BigInteger,
     hq: BigInteger,
 }


### PR DESCRIPTION
CRT only, also benching sampling (~1.8x speedup):
```
test self::bench_encryption_dk<KeySize2048>   ... bench:   7,129,363 ns/iter (+/- 540,764)
test self::bench_encryption_dk<KeySize4096>   ... bench:  54,242,799 ns/iter (+/- 7,682,649)
test self::bench_encryption_ek<KeySize2048>   ... bench:  12,946,351 ns/iter (+/- 649,587)
test self::bench_encryption_ek<KeySize4096>   ... bench: 102,422,321 ns/iter (+/- 24,311,324)
```

CRT + Rayon, also benching sampling (~3.5x faster):
```
test self::bench_encryption_dk<KeySize2048>   ... bench:   3,667,558 ns/iter (+/- 229,985)
test self::bench_encryption_dk<KeySize4096>   ... bench:  27,343,016 ns/iter (+/- 4,941,851)
test self::bench_encryption_ek<KeySize2048>   ... bench:  12,776,994 ns/iter (+/- 650,160)
test self::bench_encryption_ek<KeySize4096>   ... bench: 102,888,528 ns/iter (+/- 24,249,730)
```