### PR TITLE
Update ring crate to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ramp = { version="0.3", optional=true }
 framp = { version="0.3", optional=true }
 num = { version="0.1", optional=true }
 rust-gmp = { version="0.5", optional=true }
-ring = { version="0.12", optional=true }
+ring = { version="0.13", optional=true }
 rayon = "1.0"
 bit-vec = "0.5"
 


### PR DESCRIPTION
Following https://github.com/KZen-networks/cryptography-utils/pull/5, the build fails on Travis:
```
error: multiple packages link to native library `ring-asm`, but a native library can be linked only once
package `ring v0.13.2`
    ... which is depended on by `cryptography-utils v0.1.0 (https://github.com/KZen-networks/cryptography-utils#3869226f)`
    ... which is depended on by `multi-party-ecdsa v0.1.0 (file:///home/travis/build/KZen-networks/multi-party-ecdsa)`
links to native library `ring-asm`
package `ring v0.12.1`
    ... which is depended on by `paillier v0.2.0-pre (https://github.com/mortendahl/rust-paillier?branch=dev#0916f46c)`
    ... which is depended on by `multi-party-ecdsa v0.1.0 (file:///home/travis/build/KZen-networks/multi-party-ecdsa)`
also links to native library `ring-asm`
```
https://travis-ci.com/KZen-networks/multi-party-ecdsa/jobs/136548291#L495

Sorry for breaking the build...